### PR TITLE
Add link to helm resource.

### DIFF
--- a/docs/using-concourse/resource-types.any
+++ b/docs/using-concourse/resource-types.any
@@ -159,6 +159,8 @@ before using it!
   }{
     \hyperlink{https://github.com/jcderr/concourse-kubernetes-resource}{Kubernetes}
   }{
+    \hyperlink{https://github.com/linkyard/concourse-helm-resource}{Kubernetes Helm}
+  }{
     \hyperlink{https://github.com/Docurated/concourse-vault-resource}{Vault}
   }{
     \hyperlink{https://github.com/everpeace/aws-kms-resource}{AWS Key Management Service}


### PR DESCRIPTION
We implemented a new 3rd party resource type to deployment resources with kubernetes helm.

See the documentation in the linked github repo: https://github.com/linkyard/concourse-helm-resource